### PR TITLE
Bugfix: Repo url syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Jayant Dabas (http://dabasjayant.github.io)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dabasjayant/bcrypt-lite.git"
+    "url": "git+https://github.com/dabasjayant/bcrypt-lite.git"
   },
   "bugs": {
     "url": "https://github.com/dabasjayant/bcrypt-lite/issues"


### PR DESCRIPTION
**Changes**
- Added `git+...` as a prefix to the repo url